### PR TITLE
Add Express backend skeleton

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# Linora Full‑Stack Architecture
+
+This document provides an overview of the proposed backend architecture for the Linora e‑commerce platform.
+
+## Overview
+The frontend (React 18 + TypeScript) communicates with a Node.js/Express backend. PostgreSQL is used as the primary database and Prisma handles ORM.
+
+## Authentication
+- **Roles**: `buyer`, `tajira`, `model`, `admin`.
+- JWT based auth with refresh tokens.
+- Email/SMS verification hooks in `src/utils` (implement with real provider).
+- Middleware `authenticate` enforces role-based access.
+
+## API Routes
+- `POST /api/auth/register` – create account.
+- `POST /api/auth/login` – obtain JWT.
+- `GET /api/users/me` – view profile.
+- `PUT /api/users/me` – update profile.
+- `GET /api/products` – list products.
+- `POST /api/products` – create product (tajira/admin).
+- `PUT /api/products/:id` – update product.
+- `DELETE /api/products/:id` – remove product.
+- `GET /api/orders` – list authenticated user orders.
+- `POST /api/orders` – create order from cart.
+- `GET /api/admin/users` – admin user list.
+- `GET /api/admin/complaints` – complaint moderation.
+
+## Database Schema
+See `server/prisma/schema.prisma` for full schema. Key tables:
+- **User** – stores authentication info and role.
+- **Product** – products offered by a tajira.
+- **Order / OrderItem** – purchase records.
+- **Complaint** – admin moderation records.
+- **ModelProfile** – additional data for model accounts.
+
+Indices are automatically handled by Prisma for foreign keys and unique constraints.
+
+## File Uploads
+Use `multer` middleware to handle product and profile image uploads. Store images in a cloud bucket (e.g., S3) and save URLs in the database.
+
+## Admin Customization
+`/api/admin` routes expose endpoints for SaaS‑level customization. The `PlatformCustomizer` React component connects to these APIs.
+
+## Deployment
+- Containerize the app with Docker.
+- Use environments like AWS ECS or DigitalOcean App Platform for hosting.
+- Configure CI/CD to run Prisma migrations and deploy frontend assets.
+

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/dist
+.env

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,29 @@
+# Linora Backend
+
+This folder contains a minimal Node.js + Express backend using TypeScript and Prisma.
+
+## Features
+- JWT authentication for four roles: `buyer`, `tajira`, `model`, `admin`.
+- RESTful APIs for users, products, orders, and admin moderation.
+- File uploads via `multer` (configure in `productController` as needed).
+- PostgreSQL schema defined in `prisma/schema.prisma`.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure the database URL in `.env`:
+   ```env
+   DATABASE_URL=postgres://user:pass@localhost:5432/linora
+   JWT_SECRET=supersecret
+   ```
+3. Generate Prisma client and migrate:
+   ```bash
+   npx prisma generate
+   npx prisma migrate dev --name init
+   ```
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "linora-server",
+  "version": "1.0.0",
+  "description": "Backend for Linora e-commerce platform",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.2.0",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.1",
+    "multer": "^1.4.5-lts.1",
+    "prisma": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/morgan": "^1.9.10",
+    "@types/multer": "^1.4.7",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,73 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id       Int     @id @default(autoincrement())
+  email    String  @unique
+  password String
+  role     Role
+  products Product[]
+  orders   Order[]
+  models   ModelProfile[]
+}
+
+enum Role {
+  buyer
+  tajira
+  model
+  admin
+}
+
+model Product {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String
+  price       Float
+  imageUrl    String?
+  tajira      User     @relation(fields: [tajiraId], references: [id])
+  tajiraId    Int
+  orders      OrderItem[]
+}
+
+model Order {
+  id        Int         @id @default(autoincrement())
+  user      User        @relation(fields: [userId], references: [id])
+  userId    Int
+  createdAt DateTime    @default(now())
+  items     OrderItem[]
+  total     Float
+}
+
+model OrderItem {
+  id        Int      @id @default(autoincrement())
+  order     Order    @relation(fields: [orderId], references: [id])
+  orderId   Int
+  product   Product  @relation(fields: [productId], references: [id])
+  productId Int
+  quantity  Int
+  price     Float
+}
+
+model Complaint {
+  id        Int      @id @default(autoincrement())
+  title     String
+  detail    String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  status    String   @default("open")
+  createdAt DateTime @default(now())
+}
+
+model ModelProfile {
+  id        Int     @id @default(autoincrement())
+  user      User    @relation(fields: [userId], references: [id])
+  userId    Int
+  bio       String?
+  avatarUrl String?
+}

--- a/server/src/controllers/adminController.ts
+++ b/server/src/controllers/adminController.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from 'express';
+import prisma from '../models/prisma';
+
+export async function listUsers(req: Request, res: Response) {
+  const users = await prisma.user.findMany();
+  res.json(users);
+}
+
+export async function listComplaints(req: Request, res: Response) {
+  const complaints = await prisma.complaint.findMany();
+  res.json(complaints);
+}

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import prisma from '../models/prisma';
+
+export async function register(req: Request, res: Response) {
+  const { email, password, role } = req.body;
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await prisma.user.create({ data: { email, password: hashed, role } });
+  res.json(user);
+}
+
+export async function login(req: Request, res: Response) {
+  const { email, password } = req.body;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
+  res.json({ token });
+}

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import prisma from '../models/prisma';
+
+export async function listOrders(req: Request, res: Response) {
+  const orders = await prisma.order.findMany({ where: { userId: (req as any).user.id } });
+  res.json(orders);
+}
+
+export async function createOrder(req: Request, res: Response) {
+  const data = req.body;
+  const order = await prisma.order.create({ data: { ...data, userId: (req as any).user.id } });
+  res.json(order);
+}

--- a/server/src/controllers/productController.ts
+++ b/server/src/controllers/productController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import prisma from '../models/prisma';
+
+export async function listProducts(req: Request, res: Response) {
+  const products = await prisma.product.findMany();
+  res.json(products);
+}
+
+export async function createProduct(req: Request, res: Response) {
+  const data = req.body;
+  const product = await prisma.product.create({ data });
+  res.json(product);
+}
+
+export async function updateProduct(req: Request, res: Response) {
+  const { id } = req.params;
+  const data = req.body;
+  const product = await prisma.product.update({ where: { id: Number(id) }, data });
+  res.json(product);
+}
+
+export async function deleteProduct(req: Request, res: Response) {
+  const { id } = req.params;
+  await prisma.product.delete({ where: { id: Number(id) } });
+  res.json({ id });
+}

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import prisma from '../models/prisma';
+
+export async function getProfile(req: Request, res: Response) {
+  const userId = (req as any).user.id;
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  res.json(user);
+}
+
+export async function updateProfile(req: Request, res: Response) {
+  const userId = (req as any).user.id;
+  const data = req.body;
+  const user = await prisma.user.update({ where: { id: userId }, data });
+  res.json(user);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import cors from 'cors';
+import morgan from 'morgan';
+import authRoutes from './routes/auth';
+import userRoutes from './routes/users';
+import productRoutes from './routes/products';
+import orderRoutes from './routes/orders';
+import adminRoutes from './routes/admin';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(morgan('dev'));
+
+app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/products', productRoutes);
+app.use('/api/orders', orderRoutes);
+app.use('/api/admin', adminRoutes);
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  user?: { id: number; role: string };
+}
+
+export function authenticate(requiredRoles: string[] = []) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) return res.status(401).json({ message: 'No token provided' });
+
+    const token = authHeader.split(' ')[1];
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+      req.user = { id: decoded.id, role: decoded.role };
+      if (requiredRoles.length && !requiredRoles.includes(decoded.role)) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      next();
+    } catch (err) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+  };
+}

--- a/server/src/models/prisma.ts
+++ b/server/src/models/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+export default prisma;

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { listUsers, listComplaints } from '../controllers/adminController';
+
+const router = Router();
+router.get('/users', authenticate(['admin']), listUsers);
+router.get('/complaints', authenticate(['admin']), listComplaints);
+
+export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { register, login } from '../controllers/authController';
+
+const router = Router();
+router.post('/register', register);
+router.post('/login', login);
+
+export default router;

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { listOrders, createOrder } from '../controllers/orderController';
+
+const router = Router();
+router.get('/', authenticate(), listOrders);
+router.post('/', authenticate(), createOrder);
+
+export default router;

--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { listProducts, createProduct, updateProduct, deleteProduct } from '../controllers/productController';
+
+const router = Router();
+router.get('/', listProducts);
+router.post('/', authenticate(['tajira','admin']), createProduct);
+router.put('/:id', authenticate(['tajira','admin']), updateProduct);
+router.delete('/:id', authenticate(['tajira','admin']), deleteProduct);
+
+export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { getProfile, updateProfile } from '../controllers/userController';
+
+const router = Router();
+router.get('/me', authenticate(), getProfile);
+router.put('/me', authenticate(), updateProfile);
+
+export default router;

--- a/server/src/utils/email.ts
+++ b/server/src/utils/email.ts
@@ -1,0 +1,3 @@
+export async function sendVerificationEmail(email: string, token: string) {
+  console.log('Sending email to', email, token);
+}

--- a/server/src/utils/sms.ts
+++ b/server/src/utils/sms.ts
@@ -1,0 +1,3 @@
+export async function sendSMS(phone: string, message: string) {
+  console.log('Sending SMS to', phone, message);
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- introduce backend skeleton using Express, TypeScript and Prisma
- add API routes for auth, users, products, orders and admin tools
- provide database schema via `prisma/schema.prisma`
- document architecture in new `ARCHITECTURE.md`

## Testing
- `npm install --silent` in `server`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68842e91ba608322b4d0b78666396c00