### PR TITLE
Add prettier config and formatting script

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2
+}

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,4 +1,5 @@
 **Add your own guidelines here**
+
 <!--
 
 System Guidelines
@@ -16,6 +17,7 @@ For example:
 * Only use absolute positioning when necessary. Opt for responsive and well structured layouts that use flexbox and grid by default
 * Refactor code as you go to keep code clean
 * Keep file sizes small and put helper functions and components in their own files.
+* Run `npm run format` before committing to ensure consistent code style.
 
 --------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "linora-frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "linora-frontend",
+      "version": "1.0.0",
+      "devDependencies": {
+        "prettier": "^3.2.5"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "linora-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\""
+  },
+  "devDependencies": {
+    "prettier": "^3.2.5"
+  }
+}


### PR DESCRIPTION
## Summary
- create `.prettierrc`
- add `format` script and prettier dev dependency
- document formatting in `Guidelines.md`

## Testing
- `npm run format --silent`

------
https://chatgpt.com/codex/tasks/task_e_688452ef869c8322a7d5bc518da0297c