### PR TITLE
Add user and order enhancements

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -24,6 +24,7 @@ This folder contains the Node.js + Express backend using TypeScript and Prisma.
    ```bash
    npx prisma generate
    npx prisma migrate dev --name init
+   npx prisma migrate dev --name add-user-order-fields
    ```
 4. Start the development server:
    ```bash

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -8,14 +8,19 @@ datasource db {
 }
 
 model User {
-  id       Int     @id @default(autoincrement())
-  email    String  @unique
-  password String
-  isVerified Boolean @default(false)
-  role     Role
-  products Product[]
-  orders   Order[]
-  models   ModelProfile[]
+  id                 Int                 @id @default(autoincrement())
+  email              String              @unique
+  password           String
+  name               String
+  phone              String?
+  createdAt          DateTime            @default(now())
+  isVerified         Boolean             @default(false)
+  role               Role
+  products           Product[]
+  orders             Order[]
+  models             ModelProfile[]
+  complaints         Complaint[]
+  verificationTokens VerificationToken[]
 }
 
 enum Role {
@@ -26,12 +31,12 @@ enum Role {
 }
 
 model Product {
-  id          Int      @id @default(autoincrement())
+  id          Int         @id @default(autoincrement())
   name        String
   description String
   price       Float
   imageUrl    String?
-  tajira      User     @relation(fields: [tajiraId], references: [id])
+  tajira      User        @relation(fields: [tajiraId], references: [id])
   tajiraId    Int
   orders      OrderItem[]
 }
@@ -41,15 +46,17 @@ model Order {
   user      User        @relation(fields: [userId], references: [id])
   userId    Int
   createdAt DateTime    @default(now())
+  status    String      @default("pending")
+  paymentId String?
   items     OrderItem[]
   total     Float
 }
 
 model OrderItem {
-  id        Int      @id @default(autoincrement())
-  order     Order    @relation(fields: [orderId], references: [id])
+  id        Int     @id @default(autoincrement())
+  order     Order   @relation(fields: [orderId], references: [id])
   orderId   Int
-  product   Product  @relation(fields: [productId], references: [id])
+  product   Product @relation(fields: [productId], references: [id])
   productId Int
   quantity  Int
   price     Float
@@ -74,9 +81,9 @@ model ModelProfile {
 }
 
 model VerificationToken {
-  id        Int      @id @default(autoincrement())
-  token     String   @unique
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int
-  expires   DateTime
+  id      Int      @id @default(autoincrement())
+  token   String   @unique
+  user    User     @relation(fields: [userId], references: [id])
+  userId  Int
+  expires DateTime
 }

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -6,9 +6,11 @@ import prisma from '../models/prisma';
 import { sendVerificationEmail } from '../utils/email';
 
 export async function register(req: Request, res: Response) {
-  const { email, password, role } = req.body;
+  const { email, password, role, name, phone } = req.body;
   const hashed = await bcrypt.hash(password, 10);
-  const user = await prisma.user.create({ data: { email, password: hashed, role } });
+  const user = await prisma.user.create({
+    data: { email, password: hashed, role, name, phone }
+  });
   const token = uuid();
   await prisma.verificationToken.create({
     data: { token, userId: user.id, expires: new Date(Date.now() + 24 * 60 * 60 * 1000) }

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -7,7 +7,9 @@ export async function listOrders(req: Request, res: Response) {
 }
 
 export async function createOrder(req: Request, res: Response) {
-  const data = req.body;
-  const order = await prisma.order.create({ data: { ...data, userId: (req as any).user.id } });
+  const { status, paymentId, ...data } = req.body;
+  const order = await prisma.order.create({
+    data: { ...data, status, paymentId, userId: (req as any).user.id }
+  });
   res.json(order);
 }


### PR DESCRIPTION
## Summary
- expand `User` model with profile fields
- expand `Order` model with status and payment ID
- document new migration command
- handle extra fields in auth and order controllers

## Testing
- `npm run build`
- `npx prisma migrate dev --name add-user-order-fields --create-only` *(fails: Can't reach database server)*


------
https://chatgpt.com/codex/tasks/task_e_688452ece408832293fb6a378a3b1e42