### PR TITLE
Add centralized error handling

### DIFF
--- a/server/src/controllers/adminController.ts
+++ b/server/src/controllers/adminController.ts
@@ -1,12 +1,20 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../models/prisma';
 
-export async function listUsers(req: Request, res: Response) {
-  const users = await prisma.user.findMany();
-  res.json(users);
+export async function listUsers(req: Request, res: Response, next: NextFunction) {
+  try {
+    const users = await prisma.user.findMany();
+    res.json(users);
+  } catch (err) {
+    next(err);
+  }
 }
 
-export async function listComplaints(req: Request, res: Response) {
-  const complaints = await prisma.complaint.findMany();
-  res.json(complaints);
+export async function listComplaints(req: Request, res: Response, next: NextFunction) {
+  try {
+    const complaints = await prisma.complaint.findMany();
+    res.json(complaints);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -1,39 +1,51 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { v4 as uuid } from 'uuid';
 import prisma from '../models/prisma';
 import { sendVerificationEmail } from '../utils/email';
 
-export async function register(req: Request, res: Response) {
-  const { email, password, role } = req.body;
-  const hashed = await bcrypt.hash(password, 10);
-  const user = await prisma.user.create({ data: { email, password: hashed, role } });
-  const token = uuid();
-  await prisma.verificationToken.create({
-    data: { token, userId: user.id, expires: new Date(Date.now() + 24 * 60 * 60 * 1000) }
-  });
-  await sendVerificationEmail(email, token);
-  res.json({ id: user.id, email: user.email });
-}
-
-export async function login(req: Request, res: Response) {
-  const { email, password } = req.body;
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) return res.status(400).json({ message: 'Invalid credentials' });
-  const valid = await bcrypt.compare(password, user.password);
-  if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
-  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
-  res.json({ token });
-}
-
-export async function verifyEmail(req: Request, res: Response) {
-  const { token } = req.params;
-  const record = await prisma.verificationToken.findUnique({ where: { token } });
-  if (!record || record.expires < new Date()) {
-    return res.status(400).json({ message: 'Invalid or expired token' });
+export async function register(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password, role } = req.body;
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { email, password: hashed, role } });
+    const token = uuid();
+    await prisma.verificationToken.create({
+      data: { token, userId: user.id, expires: new Date(Date.now() + 24 * 60 * 60 * 1000) }
+    });
+    await sendVerificationEmail(email, token);
+    res.json({ id: user.id, email: user.email });
+  } catch (err) {
+    next(err);
   }
-  await prisma.user.update({ where: { id: record.userId }, data: { isVerified: true } });
-  await prisma.verificationToken.delete({ where: { id: record.id } });
-  res.json({ message: 'Email verified' });
+}
+
+export async function login(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { email, password } = req.body;
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });
+    res.json({ token });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function verifyEmail(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { token } = req.params;
+    const record = await prisma.verificationToken.findUnique({ where: { token } });
+    if (!record || record.expires < new Date()) {
+      return res.status(400).json({ message: 'Invalid or expired token' });
+    }
+    await prisma.user.update({ where: { id: record.userId }, data: { isVerified: true } });
+    await prisma.verificationToken.delete({ where: { id: record.id } });
+    res.json({ message: 'Email verified' });
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/controllers/complaintController.ts
+++ b/server/src/controllers/complaintController.ts
@@ -1,11 +1,15 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../models/prisma';
 
-export async function createComplaint(req: Request, res: Response) {
-  const userId = (req as any).user.id;
-  const { title, detail } = req.body;
-  const complaint = await prisma.complaint.create({
-    data: { title, detail, userId }
-  });
-  res.json(complaint);
+export async function createComplaint(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = (req as any).user.id;
+    const { title, detail } = req.body;
+    const complaint = await prisma.complaint.create({
+      data: { title, detail, userId }
+    });
+    res.json(complaint);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/controllers/orderController.ts
+++ b/server/src/controllers/orderController.ts
@@ -1,13 +1,21 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../models/prisma';
 
-export async function listOrders(req: Request, res: Response) {
-  const orders = await prisma.order.findMany({ where: { userId: (req as any).user.id } });
-  res.json(orders);
+export async function listOrders(req: Request, res: Response, next: NextFunction) {
+  try {
+    const orders = await prisma.order.findMany({ where: { userId: (req as any).user.id } });
+    res.json(orders);
+  } catch (err) {
+    next(err);
+  }
 }
 
-export async function createOrder(req: Request, res: Response) {
-  const data = req.body;
-  const order = await prisma.order.create({ data: { ...data, userId: (req as any).user.id } });
-  res.json(order);
+export async function createOrder(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = req.body;
+    const order = await prisma.order.create({ data: { ...data, userId: (req as any).user.id } });
+    res.json(order);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/controllers/productController.ts
+++ b/server/src/controllers/productController.ts
@@ -1,32 +1,48 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../models/prisma';
 
-export async function listProducts(req: Request, res: Response) {
-  const products = await prisma.product.findMany();
-  res.json(products);
-}
-
-export async function createProduct(req: Request, res: Response) {
-  const data = req.body;
-  if (req.file) {
-    (data as any).imageUrl = `/uploads/${req.file.filename}`;
+export async function listProducts(req: Request, res: Response, next: NextFunction) {
+  try {
+    const products = await prisma.product.findMany();
+    res.json(products);
+  } catch (err) {
+    next(err);
   }
-  const product = await prisma.product.create({ data });
-  res.json(product);
 }
 
-export async function updateProduct(req: Request, res: Response) {
-  const { id } = req.params;
-  const data = req.body;
-  if (req.file) {
-    (data as any).imageUrl = `/uploads/${req.file.filename}`;
+export async function createProduct(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = req.body;
+    if (req.file) {
+      (data as any).imageUrl = `/uploads/${req.file.filename}`;
+    }
+    const product = await prisma.product.create({ data });
+    res.json(product);
+  } catch (err) {
+    next(err);
   }
-  const product = await prisma.product.update({ where: { id: Number(id) }, data });
-  res.json(product);
 }
 
-export async function deleteProduct(req: Request, res: Response) {
-  const { id } = req.params;
-  await prisma.product.delete({ where: { id: Number(id) } });
-  res.json({ id });
+export async function updateProduct(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    const data = req.body;
+    if (req.file) {
+      (data as any).imageUrl = `/uploads/${req.file.filename}`;
+    }
+    const product = await prisma.product.update({ where: { id: Number(id) }, data });
+    res.json(product);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteProduct(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    await prisma.product.delete({ where: { id: Number(id) } });
+    res.json({ id });
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -1,15 +1,23 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import prisma from '../models/prisma';
 
-export async function getProfile(req: Request, res: Response) {
-  const userId = (req as any).user.id;
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  res.json(user);
+export async function getProfile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = (req as any).user.id;
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
 }
 
-export async function updateProfile(req: Request, res: Response) {
-  const userId = (req as any).user.id;
-  const data = req.body;
-  const user = await prisma.user.update({ where: { id: userId }, data });
-  res.json(user);
+export async function updateProfile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = (req as any).user.id;
+    const data = req.body;
+    const user = await prisma.user.update({ where: { id: userId }, data });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import productRoutes from './routes/products';
 import orderRoutes from './routes/orders';
 import adminRoutes from './routes/admin';
 import complaintRoutes from './routes/complaints';
+import { errorHandler } from './middleware/errorHandler';
 
 dotenv.config();
 const app = express();
@@ -22,6 +23,7 @@ app.use('/api/products', productRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/complaints', complaintRoutes);
+app.use(errorHandler);
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,8 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  const status = err.status || 500;
+  const message = err.message || 'Internal server error';
+  console.error(err);
+  res.status(status).json({ message });
+}


### PR DESCRIPTION
## Summary
- implement error-handling middleware
- wrap controller logic in try/catch blocks
- attach the error handler in the Express app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688452ebe34483229b6e940030b61e11