### PR TITLE
Enforce email verification on login

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts']
+};

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "@prisma/client": "^5.2.0",
@@ -29,6 +30,9 @@
     "@types/morgan": "^1.9.10",
     "@types/multer": "^1.4.7",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/jest": "^29.5.8",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/server/src/controllers/__tests__/authController.test.ts
+++ b/server/src/controllers/__tests__/authController.test.ts
@@ -1,0 +1,37 @@
+import { login } from '../authController';
+import prisma from '../../models/prisma';
+
+jest.mock('../../models/prisma', () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: jest.fn()
+    }
+  }
+}));
+
+function createResponse() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('login', () => {
+  it('rejects unverified users', async () => {
+    const req: any = { body: { email: 'test@example.com', password: 'secret' } };
+    const res = createResponse();
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      password: 'hash',
+      role: 'buyer',
+      isVerified: false
+    });
+
+    await login(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Email not verified' });
+  });
+});

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -21,6 +21,9 @@ export async function login(req: Request, res: Response) {
   const { email, password } = req.body;
   const user = await prisma.user.findUnique({ where: { email } });
   if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+  if (!user.isVerified) {
+    return res.status(403).json({ message: 'Email not verified' });
+  }
   const valid = await bcrypt.compare(password, user.password);
   if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
   const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '7d' });


### PR DESCRIPTION
## Summary
- block login for unverified users with 403
- add Jest infrastructure and unit test

## Testing
- `npm install --silent` in `server`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688452eb00988322b6322f020cd2c238