### PR TITLE
feat(server): add global error handling

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import productRoutes from './routes/products';
 import orderRoutes from './routes/orders';
 import adminRoutes from './routes/admin';
 import complaintRoutes from './routes/complaints';
+import errorHandler from './middleware/errorHandler';
 
 dotenv.config();
 const app = express();
@@ -22,6 +23,8 @@ app.use('/api/products', productRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/complaints', complaintRoutes);
+
+app.use(errorHandler);
 
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {

--- a/server/src/middleware/asyncHandler.ts
+++ b/server/src/middleware/asyncHandler.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export default function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+): RequestHandler {
+  return function (req: Request, res: Response, next: NextFunction) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,8 @@
+import { Request, Response, NextFunction } from 'express';
+
+export default function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  console.error(err);
+  const status = err.status || 500;
+  const message = err.message || 'Internal server error';
+  res.status(status).json({ message });
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import asyncHandler from '../middleware/asyncHandler';
 import { listUsers, listComplaints } from '../controllers/adminController';
 
 const router = Router();
-router.get('/users', authenticate(['admin']), listUsers);
-router.get('/complaints', authenticate(['admin']), listComplaints);
+router.get('/users', authenticate(['admin']), asyncHandler(listUsers));
+router.get('/complaints', authenticate(['admin']), asyncHandler(listComplaints));
 
 export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
+import asyncHandler from '../middleware/asyncHandler';
 import { register, login, verifyEmail } from '../controllers/authController';
 
 const router = Router();
-router.post('/register', register);
-router.post('/login', login);
-router.get('/verify/:token', verifyEmail);
+router.post('/register', asyncHandler(register));
+router.post('/login', asyncHandler(login));
+router.get('/verify/:token', asyncHandler(verifyEmail));
 
 export default router;

--- a/server/src/routes/complaints.ts
+++ b/server/src/routes/complaints.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import asyncHandler from '../middleware/asyncHandler';
 import { createComplaint } from '../controllers/complaintController';
 
 const router = Router();
-router.post('/', authenticate(), createComplaint);
+router.post('/', authenticate(), asyncHandler(createComplaint));
 
 export default router;

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import asyncHandler from '../middleware/asyncHandler';
 import { listOrders, createOrder } from '../controllers/orderController';
 
 const router = Router();
-router.get('/', authenticate(), listOrders);
-router.post('/', authenticate(), createOrder);
+router.get('/', authenticate(), asyncHandler(listOrders));
+router.post('/', authenticate(), asyncHandler(createOrder));
 
 export default router;

--- a/server/src/routes/products.ts
+++ b/server/src/routes/products.ts
@@ -1,12 +1,27 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import asyncHandler from '../middleware/asyncHandler';
 import { listProducts, createProduct, updateProduct, deleteProduct } from '../controllers/productController';
 import { upload } from '../middleware/upload';
 
 const router = Router();
-router.get('/', listProducts);
-router.post('/', authenticate(['tajira','admin']), upload.single('image'), createProduct);
-router.put('/:id', authenticate(['tajira','admin']), upload.single('image'), updateProduct);
-router.delete('/:id', authenticate(['tajira','admin']), deleteProduct);
+router.get('/', asyncHandler(listProducts));
+router.post(
+  '/',
+  authenticate(['tajira', 'admin']),
+  upload.single('image'),
+  asyncHandler(createProduct)
+);
+router.put(
+  '/:id',
+  authenticate(['tajira', 'admin']),
+  upload.single('image'),
+  asyncHandler(updateProduct)
+);
+router.delete(
+  '/:id',
+  authenticate(['tajira', 'admin']),
+  asyncHandler(deleteProduct)
+);
 
 export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth';
+import asyncHandler from '../middleware/asyncHandler';
 import { getProfile, updateProfile } from '../controllers/userController';
 
 const router = Router();
-router.get('/me', authenticate(), getProfile);
-router.put('/me', authenticate(), updateProfile);
+router.get('/me', authenticate(), asyncHandler(getProfile));
+router.put('/me', authenticate(), asyncHandler(updateProfile));
 
 export default router;


### PR DESCRIPTION
## Summary
- add async error handler helper
- implement errorHandler middleware for consistent JSON responses
- wrap all async controllers with the helper
- register error handler middleware in the Express app

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688467c298a483228886fb43f64a8431